### PR TITLE
Convertidor de textos largos

### DIFF
--- a/convertidor.js
+++ b/convertidor.js
@@ -1,3 +1,78 @@
+let separadores = ".,-";
+let nombre_separadores = {
+    ".": "punto",
+    ",": "coma",
+    "-": "guión"
+};
+
+
+function convertir_masivo() {
+    var origen = document.getElementById("origen").value;
+    var destino = document.getElementById("resultado");
+
+    var resultado = "";
+    var digitos = "0123456789";
+    var palabra = "";
+    // 0: fuera de número. 1: en número
+    var q = 0;
+    for (var i = 0; i < origen.length; ++i) {
+        if (q == 0) {
+            if (digitos.includes(origen[i])) {
+                palabra = origen[i];
+                q = 1;
+            } else {
+                resultado += origen[i];
+            }
+        } else {
+            if (digitos.includes(origen[i]) || separadores.includes(origen[i])) {
+                palabra += origen[i];
+            } else {
+                resultado += convertir_sucio(palabra);
+                resultado += origen[i];
+                palabra = "";
+                q = 0;
+            }
+        }
+    }
+    if (palabra.length > 0) {
+        resultado += convertir_sucio(palabra);
+    }
+    destino.value = resultado;
+}
+
+function convertir_sucio(palabra) {
+    // descartar separadores del final,
+    // asumiendo que son puntuación
+    var final = "";
+    var i = palabra.length - 1
+    for (; i >= 0; --i) {
+        if (separadores.includes(palabra[i])) {
+            final = palabra[i] + final;
+        } else {
+            break;
+        }
+    }
+    var numero = palabra.substring(0, i + 1);
+
+    // el último separador es el que nos interesa, el resto se borran
+    var numero_limpio = "";
+    var ultimo_separador = -1;
+    for (var i=0; i<numero.length; ++i) {
+        if (separadores.includes(numero[i])) {
+            ultimo_separador = i;
+        } else {
+            numero_limpio += numero[i];
+        }
+    }
+    if (ultimo_separador != -1) {
+        var decimales = numero.substring(ultimo_separador+1);
+        var parte_entera = numero.substring(0, ultimo_separador);
+        return parte_entera;
+    }
+
+
+    return transformarNumeroAPalabra(numero_limpio) + final;
+}
 
 function convertir() {
     var separador = ",";

--- a/convertidor.js
+++ b/convertidor.js
@@ -17,7 +17,7 @@ function convertir_masivo() {
     var q = 0;
     for (var i = 0; i < origen.length; ++i) {
         if (q == 0) {
-            if (digitos.includes(origen[i])) {
+            if (digitos.includes(origen[i]) || origen[i] == "$") {
                 palabra = origen[i];
                 q = 1;
             } else {
@@ -37,7 +37,7 @@ function convertir_masivo() {
     if (palabra.length > 0) {
         resultado += convertir_sucio(palabra);
     }
-    destino.value = resultado;
+    destino.value = resultado.replace("-k", " guión k");
 }
 
 function convertir_sucio(palabra) {
@@ -52,26 +52,24 @@ function convertir_sucio(palabra) {
             break;
         }
     }
+    if (palabra[0] == "$") {
+        final = " pesos" + final;
+        palabra = palabra.substring(1);
+        i -= 1;
+    }
     var numero = palabra.substring(0, i + 1);
 
     // el último separador es el que nos interesa, el resto se borran
-    var numero_limpio = "";
     var ultimo_separador = -1;
-    for (var i=0; i<numero.length; ++i) {
+    for (var i = 0; i < numero.length; ++i) {
         if (separadores.includes(numero[i])) {
             ultimo_separador = i;
-        } else {
-            numero_limpio += numero[i];
         }
     }
     if (ultimo_separador != -1) {
-        var decimales = numero.substring(ultimo_separador+1);
-        var parte_entera = numero.substring(0, ultimo_separador);
-        return parte_entera;
+        return convertir_con_separador(numero, numero[ultimo_separador]) + final;
     }
-
-
-    return transformarNumeroAPalabra(numero_limpio) + final;
+    return transformarNumeroAPalabra(numero) + final;
 }
 
 function convertir() {
@@ -102,7 +100,26 @@ function convertir() {
             destino.value += " " + transformarNumeroAPalabra(parseInt(c));
         }
     }
+}
 
+function convertir_con_separador(origen, separador) {
+    var nombre_separador = nombre_separadores[separador];
+    var texto_limpio = limpiar(origen, separador);
+
+    var partes = texto_limpio.split(separador);
+    if (partes[0].length > 15 || partes.length > 2) {
+        return origen;
+    }
+
+    var convertido = transformarNumeroAPalabra(parseInt(partes[0]));
+
+    if (partes.length == 2 && partes[1].length > 0) {
+        convertido += " " + nombre_separador;
+        for (c of partes[1]) {
+            convertido += " " + transformarNumeroAPalabra(parseInt(c));
+        }
+    }
+    return convertido;
 }
 
 function limpiar(texto_origen, separador) {

--- a/convertidor_masivo.html
+++ b/convertidor_masivo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+
+<head>
+    <title>Convertidor de números</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+    <link rel="icon" type="image/vnd.microsoft.icon" href="favicon.ico" />
+    <link rel="stylesheet" href="dnd.css" />
+    <script type="text/javascript" src="convertidor.js?1"></script>
+</head>
+
+<body>
+    <p>
+        Pega el texto:
+        <br />
+        <textarea id="origen" rows="15" cols="80" onkeyup="convertir_masivo()"></textarea>
+        <br /> Resultado:
+        <br />
+        <textarea id="resultado" rows="15" cols="80"></textarea>
+    </p>
+    <p>
+        <a href="http://validator.w3.org/check?uri=https://jisaa.github.io/numeros/convertidor.html">
+            <img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0 Strict" />
+        </a>
+    </p>
+</body>
+
+</html>


### PR DESCRIPTION
Extrae todos los números en cifras y los convierte a palabras, manteniendo el resto sin cambios.
Convierte el signo $ en la palabra pesos después del número.